### PR TITLE
Concatenated torchopenl3 embeddings

### DIFF
--- a/hearbaseline/torchopenl3.py
+++ b/hearbaseline/torchopenl3.py
@@ -21,7 +21,7 @@ def load_model(
     verbose=False,
     # Concatenate, don't mean, to get timestamp embeddings
     # You probably want a larger hop-size for this
-    scene_embedding_mean=False,
+    scene_embedding_mean=True,
     # Length of audio used for the scene embedding
     scene_embedding_audio_length_ms=4000,
 ) -> torch.nn.Module:


### PR DESCRIPTION
This is an alternate baseline way of creating scene embeddings, which I want to try with downstream prediction. It might overfit more, or it might represent temporal information in the first four seconds better.