### PR TITLE
Pin transformers to latest version 4.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.19.2
 tensorflow>=2.0
 torch
 speechbrain
-transformers
+transformers==4.16.1
 torchcrepe
 torchopenl3
 black


### PR DESCRIPTION
This resolves issue with wav2vec2 model not finding HubertModel

Note: in colab experiments had to add  '--no-deps' to the pip install command, for this newer transformers version to install without conflicts